### PR TITLE
Add unsigned to checksum_bytes parameter of zsync_read_blocksums in o…

### DIFF
--- a/c/libzsync/zsync.c
+++ b/c/libzsync/zsync.c
@@ -116,7 +116,7 @@ struct zsync_state {
 };
 
 static int zsync_read_blocksums(struct zsync_state *zs, FILE * f,
-                                int rsum_bytes, int checksum_bytes,
+                                int rsum_bytes, unsigned int checksum_bytes,
                                 int seq_matches);
 static int zsync_sha1(struct zsync_state *zs, int fh);
 static int zsync_recompress(struct zsync_state *zs);


### PR DESCRIPTION
…rder to avoid declaration mismatch