### PR TITLE
rsumtest.c: explicitly return 0

### DIFF
--- a/c/librcksum/rsumtest.c
+++ b/c/librcksum/rsumtest.c
@@ -75,7 +75,7 @@ void perf_test_fc000000(int n) {
     printf("%d iterations, took %d.%06ds\n", n, took_us / 1000000, took_us % 1000000);
 }
 
-void main(void) {
+int main(void) {
     test_00000000();
     test_abcde();
     test_fc000000();
@@ -83,4 +83,5 @@ void main(void) {
 #if 0
     perf_test_fc000000(10000000);
 #endif
+    return 0;
 }


### PR DESCRIPTION
Checking the return code of a function that is of type void is undefined behavior. On some arches, checking the return code of main causes the test to fail, so explicitly return 0 instead.

Link to logs of failing builds on
 - arm64: https://buildd.debian.org/status/fetch.php?pkg=zsync&arch=arm64&ver=0.6.3-1&stamp=1778362284&raw=1
 - s390x: https://buildd.debian.org/status/fetch.php?pkg=zsync&arch=s390x&ver=0.6.3-1&stamp=1778363568&raw=1